### PR TITLE
More automation for metadata CSV

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,8 +49,6 @@ Normalizing the spreadsheet:
 ** The script should normalize all of the following fields itself! ** BUT, if you encounter any trouble, you can also manually normalize the CSV by combining or splitting up the following fields:
   * Combine the columns 'Notes,' 'Alternative Title,' 'Credits' into a single column 'Notes'
   * Combine the columns 'Medium of original,' 'Dimensions of original,' 'Original video standard,' 'Generation' columns into a single column 'Medium of original'
-  * Normalize the 'frame rate' column into numbers only (e.g., remove the word 'fps')
-  * Split the 'video size' column into 'Video height' and 'Video width'; only use numbers (e.g., turn '640x480' into '640' and '480')
   * Add 'urn:bampfa_accession_number:' (no quotes) before each the accession number in the 'PFA full accession number' column
 
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Creating and downloading the spreadsheet:
 
 
 Normalizing the spreadsheet:  
-In the downloaded CSV, combine or split up the following fields:
+** The script should normalize all of the following fields itself! ** BUT, if you encounter any trouble, you can also manually normalize the CSV by combining or splitting up the following fields:
   * Combine the columns 'Notes,' 'Alternative Title,' 'Credits' into a single column 'Notes'
   * Combine the columns 'Medium of original,' 'Dimensions of original,' 'Original video standard,' 'Generation' columns into a single column 'Medium of original'
   * Normalize the 'frame rate' column into numbers only (e.g., remove the word 'fps')

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -119,6 +119,11 @@ class Asset:
 		self._user = _user
 		self.rsAPI = ResourceSpaceAPI(_user)
 
+		# initializing metadata attributes required/desired by IA that don't appear in RS
+		self.description = ""
+		self.source = ""
+		self.externalidentifier = ""
+
 	def get_local_asset_path(self):
 		# see https://www.resourcespace.com/knowledge-base/api/get_resource_path
 		# construct parameters of API call as a string
@@ -222,7 +227,6 @@ class Asset:
 			dict doesn't complain that it's missing; blank fields will be removed later.
 		'''
 		# concatenate 'description' fields
-		self.description = ""
 		if self.assetMetadata['Notes'] : # if the metadata field exists (as a string), then add it to the dictionary value
 			self.description = "Notes: " + self.assetMetadata['Notes'] + "; "
 		if self.assetMetadata['Alternative Title'] :
@@ -230,7 +234,6 @@ class Asset:
 		if self.assetMetadata['Credits'] :
 			self.description += "Credits: " + self.assetMetadata['Credits']
 		# concatenate 'source' fields
-		self.source = ""
 		if self.assetMetadata['Medium of original'] :
 			self.source = "Medium of original: " + self.assetMetadata['Medium of original'] + "; "
 		if self.assetMetadata['Dimensions of original'] :
@@ -240,7 +243,6 @@ class Asset:
 		if self.assetMetadata['Generation'] :
 			self.source += "Generation: " + self.assetMetadata['Generation']
 		# add 'urn:bampfa_accession_number:' to accession # (this conforms to IA style guide)
-		self.externalidentifier = ""
 		if self.assetMetadata['PFA full accession number'] :
 			self.externalidentifier = "urn:bampfa_accession_number:" + self.assetMetadata['PFA full accession number']
 

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -215,6 +215,35 @@ class Asset:
 		elif self.mediaType == 'mp3':
 			ia_mediatype = 'audio'
 
+		# normalizing columns from csv for use in metadata dict
+		# "if" statement: if the metadata field exists (as a string), then add it to the dictionary value
+		# initializing each field to "" so that metadata dict doesn't complain that it's missing; blank fields will be removed later
+		# concatenate 'description' fields
+		self.description = ""
+		if self.assetMetadata['Notes'] :
+			self.description = "Notes: " + self.assetMetadata['Notes'] + "; "
+		if self.assetMetadata['Alternative Title'] :
+			self.description += "Alternative Title: " + self.assetMetadata['Alternative Title'] + "; "
+		if self.assetMetadata['Credits'] :
+			self.description += "Credits: " + self.assetMetadata['Credits']
+		# concatenate 'source' fields
+		self.source = ""
+		if self.assetMetadata['Medium of original'] :
+			self.source = "Medium of original: " + self.assetMetadata['Medium of original'] + "; "
+		if self.assetMetadata['Dimensions of original'] :
+			self.source += "Dimensions of original: " + self.assetMetadata['Dimensions of original'] + "; "
+		if self.assetMetadata['Original video standard'] :
+			self.source += "Original video standard: " + self.assetMetadata['Original video standard'] + "; "
+		if self.assetMetadata['Generation'] :
+			self.source += "Generation: " + self.assetMetadata['Generation']
+		# remove "fps" and leading/trailing spaces from 'frame rate' column
+		self.frames_per_second = ""
+		self.frames_per_second = self.assetMetadata['Frame rate'].strip(' fps').strip()
+		# add 'urn:bampfa_accession_number:' to accession # (this conforms to IA style guide)
+		self.externalidentifier = ""
+		if self.assetMetadata['PFA full accession number'] :
+			self.externalidentifier = "urn:bampfa_accession_number:" + self.assetMetadata['PFA full accession number']
+
 		md = {
 			# LET'S THINK ABOUT HOW TO MAKE THIS SET OF MD MORE AGNOSTIC/GENERALIZABLE
 			'collection': self.collection,
@@ -227,17 +256,13 @@ class Asset:
 			'identifier': identifier,
 			'title': self.assetMetadata['Title'],
 			'date': self.assetMetadata['Release Date'],
-			# Original columns 'Notes,' 'Alternative Title,' 'Credits' should be concatenated manually by operator into single column 'Notes'
-			'description': self.assetMetadata['Notes'],
-			# Original columns 'Medium of original,' 'Dimensions of original,' 'Original video standard,' 'Generation' columns should be concatenated manually by operator into single column 'Medium of original'
-			'source': self.assetMetadata['Medium of original'],
-			# 'frame rate' column should be normalized into numbers manually by operator
-			'frames_per_second': self.assetMetadata['Frame rate'],
+			'description': self.description,
+			'source': self.source,
+			'frames_per_second': self.frames_per_second,
 			# 'video size' column should be split into 'Video height' and 'Video width' numbers manually by operator
 			# 'source_pixel_width': self.assetMetadata['Video height'],
 			# 'source_pixel_height': self.assetMetadata['Video width'],
-			# 'PFA full accession number' column should be normalized to 'urn:bampfa_accession_number:XXXX' manually by operator
-			'external-identifier': self.assetMetadata['PFA full accession number'],
+			'external-identifier': self.externalidentifier,
 			'condition': self.assetMetadata['Original Material Condition'],
 			'sound': self.assetMetadata['PFA item sound characteristics'],
 			'color': self.assetMetadata['Color characteristics']

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -239,19 +239,10 @@ class Asset:
 			self.source += "Original video standard: " + self.assetMetadata['Original video standard'] + "; "
 		if self.assetMetadata['Generation'] :
 			self.source += "Generation: " + self.assetMetadata['Generation']
-		# remove "fps" and leading/trailing spaces from 'frame rate' column
-		self.frames_per_second = ""
-		self.frames_per_second = self.assetMetadata['Frame rate'].strip(' fps').strip()
 		# add 'urn:bampfa_accession_number:' to accession # (this conforms to IA style guide)
 		self.externalidentifier = ""
 		if self.assetMetadata['PFA full accession number'] :
 			self.externalidentifier = "urn:bampfa_accession_number:" + self.assetMetadata['PFA full accession number']
-		# split 'video size' column into 'Video height' and 'Video width' numbers
-		self.videoSize = ""
-		if self.assetMetadata['Video size'] :
-			self.videoSize = self.assetMetadata['Video size'].split("x")
-			self.videoWidth = self.videoSize[0]
-			self.videoHeight = self.videoSize[1]
 
 		md = {
 			# LET'S THINK ABOUT HOW TO MAKE THIS SET OF MD MORE AGNOSTIC/GENERALIZABLE
@@ -267,9 +258,6 @@ class Asset:
 			'date': self.assetMetadata['Release Date'],
 			'description': self.description,
 			'source': self.source,
-			'frames_per_second': self.frames_per_second,
-			'source_pixel_width': self.videoWidth,
-			'source_pixel_height': self.videoHeight,
 			'external-identifier': self.externalidentifier,
 			'condition': self.assetMetadata['Original Material Condition'],
 			'sound': self.assetMetadata['PFA item sound characteristics'],

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -215,12 +215,15 @@ class Asset:
 		elif self.mediaType == 'mp3':
 			ia_mediatype = 'audio'
 
-		# normalizing columns from csv for use in metadata dict
-		# "if" statement: if the metadata field exists (as a string), then add it to the dictionary value
-		# initializing each field to "" so that metadata dict doesn't complain that it's missing; blank fields will be removed later
+		'''
+		Normalizing columns from csv for use in metadata dict.
+			This is required because the RS and IA metadata fields do not directly
+			map to each other. Each field is initialized to "" so that the metadata
+			dict doesn't complain that it's missing; blank fields will be removed later.
+		'''
 		# concatenate 'description' fields
 		self.description = ""
-		if self.assetMetadata['Notes'] :
+		if self.assetMetadata['Notes'] : # if the metadata field exists (as a string), then add it to the dictionary value
 			self.description = "Notes: " + self.assetMetadata['Notes'] + "; "
 		if self.assetMetadata['Alternative Title'] :
 			self.description += "Alternative Title: " + self.assetMetadata['Alternative Title'] + "; "

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -229,18 +229,18 @@ class Asset:
 		'''
 		# concatenate 'description' fields
 		if self.assetMetadata['Notes'] : # if the metadata field exists (as a string), then add it to the dictionary value
-			self.description = "Notes: " + self.assetMetadata['Notes'] + "; "
+			self.description = "Notes: " + self.assetMetadata['Notes'] + ". "
 		if self.assetMetadata['Description'] :
-			self.description = "Description: " + self.assetMetadata['Description'] + "; "
+			self.description = "Description: " + self.assetMetadata['Description'] + ". "
 		if self.assetMetadata['Alternative Title'] :
-			self.description += "Alternative Title: " + self.assetMetadata['Alternative Title'] + "; "
+			self.description += "Alternative Title: " + self.assetMetadata['Alternative Title'] + ". "
 		if self.assetMetadata['Credits'] :
 			self.description += "Credits: " + self.assetMetadata['Credits']
 		# concatenate 'source' fields
 		if self.assetMetadata['Medium of original'] :
-			self.source = "Medium of original: " + self.assetMetadata['Medium of original'] + "; "
+			self.source = "Medium of original: " + self.assetMetadata['Medium of original'] + ". "
 		if self.assetMetadata['Dimensions of original'] :
-			self.source += "Dimensions of original: " + self.assetMetadata['Dimensions of original'] + "; "
+			self.source += "Dimensions of original: " + self.assetMetadata['Dimensions of original'] + ". "
 		# add 'urn:bampfa_accession_number:' to accession # (this conforms to IA style guide)
 		if self.assetMetadata['PFA full accession number'] :
 			self.externalidentifier = "urn:bampfa_accession_number:" + self.assetMetadata['PFA full accession number']
@@ -251,22 +251,22 @@ class Asset:
 		# audio- and video-specific fields
 		if ia_mediatype == 'movies' :
 			if self.assetMetadata['Original video format'] :
-				self.source += "Original video format: " + self.assetMetadata['Original video format'] + "; "
+				self.source += "Original video format: " + self.assetMetadata['Original video format'] + ". "
 			if self.assetMetadata['Original video standard'] :
-				self.source += "Original video standard: " + self.assetMetadata['Original video standard'] + "; "
+				self.source += "Original video standard: " + self.assetMetadata['Original video standard'] + ". "
 			if self.assetMetadata['Generation'] :
 				self.source += "Generation: " + self.assetMetadata['Generation']
 		elif ia_mediatype == 'audio' :
 			if self.assetMetadata['PFA film series'] :
-				self.description = "Pacific Film Archive film series: " + self.assetMetadata['PFA film series'] + "; "
+				self.description = "Pacific Film Archive film series: " + self.assetMetadata['PFA film series'] + ". "
 			if self.assetMetadata['Event title'] :
-				self.description = "Event title: " + self.assetMetadata['Event title'] + "; "
+				self.description = "Event title: " + self.assetMetadata['Event title'] + ". "
 			if self.assetMetadata['Speaker/Interviewee'] :
-				self.description = "Speaker/Interviewee: " + self.assetMetadata['Speaker/Interviewee'] + "; "
+				self.description = "Speaker/Interviewee: " + self.assetMetadata['Speaker/Interviewee'] + ". "
 			if self.assetMetadata['Subject(s): Film title(s)'] :
-				self.description = "Subject(s): Film title(s): " + self.assetMetadata['Subject(s): Film title(s)'] + "; "
+				self.description = "Subject(s): Film title(s): " + self.assetMetadata['Subject(s): Film title(s)'] + ". "
 			if self.assetMetadata['Subject(s): Topics(s)'] :
-				self.description = "Subject(s): Topics(s): " + self.assetMetadata['Subject(s): Topics(s)'] + "; "
+				self.description = "Subject(s): Topics(s): " + self.assetMetadata['Subject(s): Topics(s)'] + ". "
 
 		# general MD dict
 		general_md = {

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -302,6 +302,9 @@ class Asset:
 
 		# get rid of empty values in the md dictionary
 		md = {k: v for k, v in md.items() if v not in (None,'')}
+		# remove line breaks that display as literal "<br/>"
+		md = {v.replace('<br/>', ' '): k
+			for k, v in md.items()}
 		# archive.org Python Library, 'uploading': https://archive.org/services/docs/api/internetarchive/quickstart.html#uploading
 		print("ACCESS COPY FILENAME:")
 		print(identifier)

--- a/rs2ia.py
+++ b/rs2ia.py
@@ -243,6 +243,12 @@ class Asset:
 		self.externalidentifier = ""
 		if self.assetMetadata['PFA full accession number'] :
 			self.externalidentifier = "urn:bampfa_accession_number:" + self.assetMetadata['PFA full accession number']
+		# split 'video size' column into 'Video height' and 'Video width' numbers
+		self.videoSize = ""
+		if self.assetMetadata['Video size'] :
+			self.videoSize = self.assetMetadata['Video size'].split("x")
+			self.videoWidth = self.videoSize[0]
+			self.videoHeight = self.videoSize[1]
 
 		md = {
 			# LET'S THINK ABOUT HOW TO MAKE THIS SET OF MD MORE AGNOSTIC/GENERALIZABLE
@@ -259,9 +265,8 @@ class Asset:
 			'description': self.description,
 			'source': self.source,
 			'frames_per_second': self.frames_per_second,
-			# 'video size' column should be split into 'Video height' and 'Video width' numbers manually by operator
-			# 'source_pixel_width': self.assetMetadata['Video height'],
-			# 'source_pixel_height': self.assetMetadata['Video width'],
+			'source_pixel_width': self.videoWidth,
+			'source_pixel_height': self.videoHeight,
 			'external-identifier': self.externalidentifier,
 			'condition': self.assetMetadata['Original Material Condition'],
 			'sound': self.assetMetadata['PFA item sound characteristics'],


### PR DESCRIPTION
Automatic concatenation of columns, plus adding/removing strings from other columns. Needs review by someone who actually knows Python as it could be more elegant (though this does seem to work). There are a lot of "if" statements because I didn't want to assign the same generic text to objects without those fields (e.g. uploads shouldn't say "urn:bampfa_accession_number:" if there's no accession # at the end of it).